### PR TITLE
Removed use of CPP to guard Trustworthy

### DIFF
--- a/Pipes/Text.hs
+++ b/Pipes/Text.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE RankNTypes, TypeFamilies, BangPatterns, CPP #-}
-#if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
+{-# LANGUAGE RankNTypes, TypeFamilies, BangPatterns, Trustworthy #-}
+
 {-| This module provides @pipes@ utilities for \"text streams\", which are
     streams of 'Text' chunks. The individual chunks are uniformly @strict@, but 
     a 'Producer' can be converted to and from lazy 'Text's, though this is generally 


### PR DESCRIPTION
The CPP guard is only required for GHC 7.2 and older, but even Debian stable
packs GHC 7.4.  Also, CPP currently causes problems on OSX because of the
transition to clang so I'm currently being very conservative about using it.
When I originally started using the CPP guards GHC 6.12 was still a supported
compiler for `pipes`, but it's not any longer.
