### PR TITLE
Loosen lower bound on `tex` for `noio`

### DIFF
--- a/pipes-text.cabal
+++ b/pipes-text.cabal
@@ -44,7 +44,7 @@ library
   exposed-modules:     Pipes.Text, Pipes.Text.Encoding
   build-depends:       base >= 4                  && < 5  ,
                        bytestring >= 0.9                  ,
-                       text >=0.11.3              && < 1.2,
+                       text >=0.11.2              && < 1.2,
                        text-stream-decode >= 0.1  && < 0.2,  
                        profunctors  >= 3.1.1      && < 4.1,
                        pipes >=4.0                && < 4.2,


### PR DESCRIPTION
This lowers the bound on `text` when compiling with `-f noio`
