### PR TITLE
Updated version bound of pipes-safe

### DIFF
--- a/pipes-text.cabal
+++ b/pipes-text.cabal
@@ -43,7 +43,7 @@ library
   build-depends:       base              >= 4       && < 5  ,
                        bytestring        >= 0.9.2.1 && < 0.11,
                        text              >= 0.11.2  && < 1.3 ,
-                       streaming-commons >= 0.1     && < 0.2 ,  
+                       streaming-commons >= 0.1     && < 0.3 ,
                        pipes             >= 4.0     && < 4.4 ,
                        pipes-group       >= 1.0.0   && < 1.1 ,
                        pipes-parse       >= 3.0.0   && < 3.1 ,

--- a/pipes-text.cabal
+++ b/pipes-text.cabal
@@ -47,7 +47,7 @@ library
                        pipes             >= 4.0     && < 4.4 ,
                        pipes-group       >= 1.0.0   && < 1.1 ,
                        pipes-parse       >= 3.0.0   && < 3.1 ,
-                       pipes-safe        >= 2.1     && < 2.3 , 
+                       pipes-safe        >= 2.1     && < 2.4 , 
                        pipes-bytestring  >= 1.0     && < 2.2 ,
                        transformers      >= 0.2.0.0 && < 0.6
 


### PR DESCRIPTION
`pipes-safe-2.3` was updated to work with ghc `8.6`.  This was
a breaking change introducing `MonadFail` instances.